### PR TITLE
fix #194 new basis with `basis` arg on ``well.df()``

### DIFF
--- a/tests/test_well.py
+++ b/tests/test_well.py
@@ -106,6 +106,15 @@ def test_df(well):
     assert df.iloc[10, 1] - 46.69865036 < 0.001
     assert df.shape == (12718, 3)
 
+    # test with passing a basis
+    basis = df.reset_index().DEPT.iloc[20:40].values
+    df = well.df(basis=basis)
+    assert len(df) == 20
+    assert all(df.index.values == basis)
+
+    df = well.df(basis=[4, 5, 6, 7])
+    assert all(df.index.values == [4, 5, 6, 7])
+
 
 def test_read_df(df):
     """


### PR DESCRIPTION
Fix for issue #194 

- Adding `well.unify_basis(basis)` when `well.df(basis=basis)`.
- Added unit tests for  `well.df(basis=basis)`
