### PR TITLE
Fix plot 2d curve

### DIFF
--- a/welly/plot.py
+++ b/welly/plot.py
@@ -393,9 +393,14 @@ def plot_2d_curve(curve,
                                  x2=np.nanmin(curve_data),
                                  facecolor='none',
                                  **kwargs)
+        
+        # Combine the paths into a single Path object
+        vertices = np.concatenate([p.vertices for p in paths._paths])
+        codes = np.concatenate([p.codes for p in paths._paths])
+        merged_paths = mpl.path.Path(vertices, codes)
 
         # Make the 'fill' mask and clip the background image with it.
-        patch = PathPatch(paths._paths[0], visible=False)
+        patch = mpl.patches.PathPatch(merged_paths, visible=False)
         ax.add_artist(patch)
         im.set_clip_path(patch)
     else:

--- a/welly/plot.py
+++ b/welly/plot.py
@@ -400,7 +400,7 @@ def plot_2d_curve(curve,
         merged_paths = mpl.path.Path(vertices, codes)
 
         # Make the 'fill' mask and clip the background image with it.
-        patch = mpl.patches.PathPatch(merged_paths, visible=False)
+        patch = PathPatch(merged_paths, visible=False)
         ax.add_artist(patch)
         im.set_clip_path(patch)
     else:


### PR DESCRIPTION
Disclaimer: I did my best to explain the following issue and propose a fix. Don't hesitate to challenge this proposal or reject the pull request if not relevant.

## Short description of the issue
Curve that contains multiple parts breaks the 2D plot with curve.

## How to reproduce
- Use a LAS file containing a curve with multiple parts (see example below).
- Load LAS file and display 2D curve:
```
las_fname = '...'
curve_name = '...'
well = Well.from_las(las_filename)
well.data[curve_name ].plot_2d(curve=True)
plt.show()
```
### Example of problematic curve
Let's say you have a LAS with NULL VALUE = -999, i.e. you can read in the LAS header:
`NULL    .      -999.0000                     : NULL VALUE`
A problematic curve would be like:
```
 192.4000
 192.5000
 -999.0000  <--- This NULL value splits the curve in two
 192.4000
 192.5000
```

### Screenshot
![image](https://github.com/agilescientific/welly/assets/11176884/7cd16340-3fc6-4861-a3ba-180ab1746375)

## Proposed fix
In `plot_2d_curve` only the first path returned by `fill_betweenx` is considered to build the `PathPatch`. As a result, the mask only covers the first portion of the curve. The rest is left blank. To fix the issue I just combined every paths into a single `PathPatch` object.

![image](https://github.com/agilescientific/welly/assets/11176884/5be32578-c8f3-430e-a3de-e0830cba13c9)
