### PR TITLE
Update github action for trusted publisher to pypi

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -13,25 +13,31 @@ on:
     types: [ published ]
 
 jobs:
-  deploy:
-
+  build_wheel:
+    name: Build wheel
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
       with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: |
-        python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        fetch-depth: 0
+    - uses: hynek/build-and-inspect-python-package@v2
+
+  deploy:
+    needs: [build_wheel]
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - uses: actions/download-artifact@v4
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        name: Packages
+        path: dist
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+    


### PR DESCRIPTION
Uses [the trusted publisher](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) approach for publishing wheels to pypi. For this to work you would still need to [update the PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).